### PR TITLE
Fix comment typo in kern_keyvalue header

### DIFF
--- a/EFI/OC/Kexts/VirtualSMC.kext/Contents/Resources/VirtualSMCSDK/kern_keyvalue.hpp
+++ b/EFI/OC/Kexts/VirtualSMC.kext/Contents/Resources/VirtualSMCSDK/kern_keyvalue.hpp
@@ -60,7 +60,7 @@ struct VirtualSMCKeyValue {
 	 *  @param out   read key data (must be preallocated)
 	 *  @param outsz key data size
 	 *
-	 *  @return true on succesful read
+         *  @return true on successful read
 	 */
 	static bool deserialize(const uint8_t *&src, uint32_t &size, SMC_KEY &name, SMC_DATA *out, SMC_DATA_SIZE &outsz);
 


### PR DESCRIPTION
## Summary
- correct "succesful" typo in VirtualSMCSDK `kern_keyvalue.hpp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860e77e64888331be1b5a7e159dcc0b