### PR TITLE
Fix duplicate SystemSerialNumber in config.plist

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1327,8 +1327,6 @@
 			<string>Auto</string>
 			<key>SystemProductName</key>
 			<string>iMac20,2</string>
-			<key>SystemSerialNumber</key>
-			<string>C02CDRZ1046M</string>
 			<key>SystemUUID</key>
 			<string>EA1D0FE7-3BCB-43C3-BD9E-F4AD2B2B17E4</string>
 		</dict>


### PR DESCRIPTION
## Summary
- remove duplicate `SystemSerialNumber` from PlatformInfo Generic section

## Testing
- `xmllint --noout EFI/OC/config.plist`

------
https://chatgpt.com/codex/tasks/task_e_6860e78573dc8331ba5b9d895c197f59